### PR TITLE
More Informative Splash Screen Status Message

### DIFF
--- a/ui/splash.go
+++ b/ui/splash.go
@@ -15,7 +15,8 @@ func NewSplashPanel(ui *UI) *SplashPanel {
 
 func (m *SplashPanel) initialize() {
 	logo := MustImageFromFile("octoprint-logo.png")
-	m.Label = MustLabel("Connecting to OctoPrint...")
+	m.Label = MustLabel("OctoPrint is waiting for printer connection...")
+	
 
 	box := MustBox(gtk.ORIENTATION_VERTICAL, 15)
 	box.SetVAlign(gtk.ALIGN_CENTER)

--- a/ui/splash.go
+++ b/ui/splash.go
@@ -16,7 +16,6 @@ func NewSplashPanel(ui *UI) *SplashPanel {
 func (m *SplashPanel) initialize() {
 	logo := MustImageFromFile("octoprint-logo.png")
 	m.Label = MustLabel("OctoPrint is waiting for printer connection...")
-	
 
 	box := MustBox(gtk.ORIENTATION_VERTICAL, 15)
 	box.SetVAlign(gtk.ALIGN_CENTER)


### PR DESCRIPTION
This was motivated by [mcuadros/OctoPrint-TFT#32](https://github.com/mcuadros/OctoPrint-TFT/issues/32) which I discovered when I experienced this same issue of the splash screen hanging despite the Pi being configured to launch OctoPrint web server at start. I was able to login to the web interface so I was confused why this app was unable to connect to it.

If the splash screen had been more informative in saying that it was waiting for a _printer to be connected to OctoPrint_ that would have saved me an hour of troubleshooting for no reason, as this touch interface works perfectly good once I just connect my 3D printer. I think others may benefit from this verbosity.

This PR is just changing a single string but I think the impact of the change is far heavier than the code change.

I was able to successfully run `make build` and I've attached the resulting [build.log](https://github.com/darksid3r/OctoPrint-TFT/files/5279272/build.log).
